### PR TITLE
Fixed redirect handler

### DIFF
--- a/Sources/ValidatorCore/Commands/CheckRedirects.swift
+++ b/Sources/ValidatorCore/Commands/CheckRedirects.swift
@@ -67,8 +67,7 @@ extension Validator {
                             return packageURL
                         case let .error(error):
                             print("ERROR: \(error)")
-                            // TODO: consider bailing out here, at least for some errors
-                            return nil
+                            throw error
                         case .redirected(let url):
                             guard !normalized.contains(url.normalized()) else {
                                 print("DELETE  \(packageURL) -> \(url) (exists)")

--- a/Sources/ValidatorCore/Commands/CheckRedirects.swift
+++ b/Sources/ValidatorCore/Commands/CheckRedirects.swift
@@ -68,6 +68,12 @@ extension Validator {
                         case let .error(error):
                             print("ERROR: \(error)")
                             throw error
+                        case .notFound:
+                            print("package \(index) ...")
+                            print("NOT FOUND:  \(packageURL.absoluteString)")
+                            return nil
+                        case .rateLimited:
+                            fatalError("rate limited - should have been retried at a lower level")
                         case .redirected(let url):
                             guard !normalized.contains(url.normalized()) else {
                                 print("DELETE  \(packageURL) -> \(url) (exists)")

--- a/Sources/ValidatorCore/RedirectFolllower.swift
+++ b/Sources/ValidatorCore/RedirectFolllower.swift
@@ -22,6 +22,7 @@ class RedirectFollower: NSObject, URLSessionTaskDelegate {
                     willPerformHTTPRedirection response: HTTPURLResponse,
                     newRequest request: URLRequest,
                     completionHandler: @escaping (URLRequest?) -> Void) {
+        print("### redirect hop to \(String(describing: request.url))")
         if let newURL = request.url {
             self.status = .redirected(to: PackageURL(rawValue: newURL))
         }

--- a/Sources/ValidatorCore/RedirectFolllower.swift
+++ b/Sources/ValidatorCore/RedirectFolllower.swift
@@ -54,14 +54,30 @@ enum Redirect {
 }
 
 
+// FIXME: clean up
+import ShellOut
+
+// TODO: drop future
 func resolveRedirects(eventLoop: EventLoop, for url: PackageURL) -> EventLoopFuture<Redirect> {
-    let promise = eventLoop.next().makePromise(of: Redirect.self)
-
-    let _ = RedirectFollower(initialURL: url) { result in
-        promise.succeed(result)
+    let cmd = ShellOutCommand(string: "curl -Ls -o /dev/null -w %{url_effective} \(url.absoluteString)")
+    do {
+        let result = try Current.shell.run(command: cmd)
+        guard let newURL = URL(string: result) else {
+            return eventLoop.makeFailedFuture(
+                AppError.runtimeError("curl for redirects returned bad url: \(result)")
+            )
+        }
+        let newPackageURL = PackageURL(rawValue: newURL)
+        return eventLoop.makeSucceededFuture(
+            url.normalized() == newPackageURL.normalized()
+                ? .initial(url)
+                : .redirected(to: newPackageURL)
+        )
+    } catch {
+        return eventLoop.makeFailedFuture(
+            AppError.runtimeError("curl for redirects failed: \(error)")
+        )
     }
-
-    return promise.futureResult
 }
 
 

--- a/Sources/ValidatorCore/RedirectFolllower.swift
+++ b/Sources/ValidatorCore/RedirectFolllower.swift
@@ -37,25 +37,10 @@ class RedirectFollower: NSObject, URLSessionTaskDelegate {
                     willPerformHTTPRedirection response: HTTPURLResponse,
                     newRequest request: URLRequest,
                     completionHandler: @escaping (URLRequest?) -> Void) {
-        print("### redirect hop to \(String(describing: request.url))")
         if let newURL = request.url {
             self.status = .redirected(to: PackageURL(rawValue: newURL))
         }
         completionHandler(request)
-    }
-
-    func urlSession(_ session: URLSession, didBecomeInvalidWithError error: Error?) {
-        print("urlSession(_:didBecomeInvalidWithError:) \(String(describing: error))")
-        if let error = error {
-            self.status = .error(error)
-        }
-    }
-
-    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
-        print("urlSession(_:task:didCompleteWithError:) \(String(describing: error))")
-        if let error = error {
-            self.status = .error(error)
-        }
     }
 }
 

--- a/Sources/ValidatorCore/RedirectFolllower.swift
+++ b/Sources/ValidatorCore/RedirectFolllower.swift
@@ -12,6 +12,10 @@ class RedirectFollower: NSObject, URLSessionTaskDelegate {
         super.init()
         self.session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
         self.task = session?.dataTask(with: initialURL.rawValue) { [weak self] (_, response, error) in
+            guard error == nil else {
+                completion(.error(error!))
+                return
+            }
             completion(self!.status)
         }
         self.task?.resume()
@@ -29,7 +33,15 @@ class RedirectFollower: NSObject, URLSessionTaskDelegate {
         completionHandler(request)
     }
 
+    func urlSession(_ session: URLSession, didBecomeInvalidWithError error: Error?) {
+        print("urlSession(_:didBecomeInvalidWithError:) \(String(describing: error))")
+        if let error = error {
+            self.status = .error(error)
+        }
+    }
+
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        print("urlSession(_:task:didCompleteWithError:) \(String(describing: error))")
         if let error = error {
             self.status = .error(error)
         }


### PR DESCRIPTION
`RedirectFollower` now reports 429s and 404s with are handled by retry and marking the url for deletion.

If [this run here](https://github.com/SwiftPackageIndex/PackageList/runs/1275978123?check_suite_focus=true) passes we can proceed with merging this PR.

EDIT: what this run does it process a package list copied from before https://github.com/SwiftPackageIndex/PackageList/pull/712 (the manual run I processed and merged this morning on my laptop to stop the rollbar items). The expectation is for this to produce the same diff (although there will be a couple more moved urls in it, as some packages have changed urls during the day).

This PR will not submit a PR but we can check the diff output in the logs.